### PR TITLE
feat: support simple color scheme

### DIFF
--- a/packages/widgets-core/src/renderer/echarts-theme.ts
+++ b/packages/widgets-core/src/renderer/echarts-theme.ts
@@ -1,6 +1,6 @@
 import { registerTheme } from 'echarts';
 
-function registerThemeDark (bg = true) {
+function registerThemeDark () {
   const contrastColor = 'rgb(200, 200, 200)';
   const bgColor = 'rgb(36, 35, 49)';
   const boxColor = 'rgb(37, 37, 39)';
@@ -151,4 +151,157 @@ function registerThemeDark (bg = true) {
   registerTheme('dark', theme);
 }
 
+function registerThemeLight () {
+  const contrastColor = 'rgb(200, 200, 200)';
+  const bgColor = '#ffffff';
+  const boxColor = '#eeeeee';
+  const borderColor = '#dddddd';
+  const axisCommon = function () {
+    return {
+      axisLine: {
+        lineStyle: {
+          color: borderColor,
+        },
+      },
+      axisTick: {
+        lineStyle: {
+          color: borderColor,
+        },
+      },
+      axisLabel: {
+        color: '#ccc',
+      },
+      splitLine: {
+        lineStyle: {
+          type: 'dashed',
+          color: '#2c2c2c',
+          width: 0.5,
+        },
+      },
+      splitArea: {
+        areaStyle: {
+          color: contrastColor,
+        },
+      },
+      axisPointer: {
+        label: {
+          backgroundColor: boxColor,
+        },
+      },
+      nameTextStyle: {
+        fontStyle: 'italic',
+        color: 'gray',
+      },
+    };
+  };
+
+  const colorPalette = ['#dd6b66', '#759aa0', '#e69d87', '#8dc1a9', '#ea7e53', '#eedd78', '#73a373', '#73b9bc', '#7289ab', '#91ca8c', '#f49f42'];
+  const theme = {
+    color: colorPalette,
+    backgroundColor: bgColor,
+    tooltip: {
+      backgroundColor: boxColor,
+      textStyle: {
+        color: contrastColor,
+      },
+      borderWidth: 0,
+      shadowBlur: 8,
+      shadowColor: 'rgba(0, 0, 0, 0.382)',
+      shadowOffsetX: 0,
+      shadowOffsetY: 0,
+      axisPointer: {
+        lineStyle: {
+          color: contrastColor,
+        },
+        crossStyle: {
+          color: contrastColor,
+        },
+      },
+      renderMode: 'html',
+    },
+    grid: {
+      containLabel: true,
+    },
+    legend: {
+      textStyle: {
+        color: contrastColor,
+      },
+    },
+    textStyle: {
+      color: contrastColor,
+    },
+    title: {
+      left: 'center',
+      top: 8,
+      textStyle: {
+        color: contrastColor,
+        fontSize: 14,
+        align: 'center',
+      },
+    },
+    toolbox: {
+      iconStyle: {
+        borderColor: contrastColor,
+      },
+    },
+    dataZoom: {
+      textStyle: {
+        color: contrastColor,
+      },
+    },
+    timeline: {
+      lineStyle: {
+        color: contrastColor,
+      },
+      itemStyle: {
+        color: colorPalette[1],
+      },
+      label: {
+        color: contrastColor,
+      },
+      controlStyle: {
+        color: contrastColor,
+        borderColor: contrastColor,
+      },
+    },
+    timeAxis: axisCommon(),
+    logAxis: axisCommon(),
+    valueAxis: axisCommon(),
+    categoryAxis: axisCommon(),
+
+    line: {
+      symbol: 'circle',
+    },
+    graph: {
+      color: colorPalette,
+    },
+    gauge: {
+      title: {
+        textStyle: {
+          color: contrastColor,
+        },
+      },
+    },
+    candlestick: {
+      itemStyle: {
+        color: '#FD1050',
+        color0: '#0CF49B',
+        borderColor: '#FD1050',
+        borderColor0: '#0CF49B',
+      },
+    },
+
+    visualMap: {
+      textStyle: {
+        color: contrastColor,
+      },
+    },
+  };
+  // @ts-expect-error
+  theme.categoryAxis.splitLine.show = false;
+  registerTheme('light', theme);
+}
+
+
 registerThemeDark();
+registerThemeLight();

--- a/packages/widgets-core/src/renderer/echarts-theme.ts
+++ b/packages/widgets-core/src/renderer/echarts-theme.ts
@@ -174,7 +174,7 @@ function registerThemeLight () {
       splitLine: {
         lineStyle: {
           type: 'dashed',
-          color: '#2c2c2c',
+          color: '#d8d8d8',
           width: 0.5,
         },
       },

--- a/packages/widgets-core/src/renderer/node/builtin.ts
+++ b/packages/widgets-core/src/renderer/node/builtin.ts
@@ -1,6 +1,7 @@
 import { Canvas, loadImage, Path2D } from '@napi-rs/canvas';
 
 type BuiltinProps<P> = {
+  colorScheme?: string
   box: {
     dpr: number
     left: number
@@ -20,12 +21,12 @@ export function renderCardHeader (canvas: Canvas, props: BuiltinProps<{ title: s
 
   ctx.textAlign = 'start';
   ctx.font = `bold ${14 * dpr}px`;
-  ctx.fillStyle = 'rgb(193,193,193)';
+  ctx.fillStyle = props.colorScheme === 'light' ? 'rgb(62, 62, 63)' : 'rgb(193,193,193)';
   ctx.fillText(title, left, top + height / 2, width);
 
   ctx.textAlign = 'end';
   ctx.font = `normal italic ${12 * dpr}px`;
-  ctx.fillStyle = 'rgb(124,124,124)';
+  ctx.fillStyle =props.colorScheme === 'light' ? 'rgb(121, 121, 121)' : 'rgb(124,124,124)';
   ctx.fillText(subtitle, left + width, top + height / 2, width);
 
   ctx.restore();
@@ -41,14 +42,14 @@ export function renderLabelValue (canvas: Canvas, props: BuiltinProps<{ label: s
   ctx.textAlign = 'start';
 
   ctx.font = `normal ${12 * dpr}px`;
-  ctx.fillStyle = 'white';
+  ctx.fillStyle = props.colorScheme === 'light' ? 'black' : 'white';
   ctx.fillText(label, left, top, width);
 
   const measured = ctx.measureText(label);
   const fontHeight = measured.fontBoundingBoxAscent + measured.fontBoundingBoxDescent;
 
   ctx.font = `bold ${24 * dpr}px`;
-  ctx.fillStyle = 'white';
+  ctx.fillStyle = props.colorScheme === 'light' ? 'black' : 'white'
   value && ctx.fillText(String(value), left, top + fontHeight + 4 * dpr, width);
 
   ctx.restore();
@@ -71,7 +72,7 @@ export async function renderAvatarLabel(
   ctx.textAlign = 'start';
 
   ctx.font = `normal ${12 * dpr}px`;
-  ctx.fillStyle = 'white';
+  ctx.fillStyle = props.colorScheme === 'light' ? 'black' : 'white';
   label && ctx.fillText(label, left + 30 * dpr, top + 7 * dpr, width);
 
   try {
@@ -84,7 +85,7 @@ export async function renderAvatarLabel(
     ctx.clip(circlePath);
     ctx.drawImage(avatar, left, top + 2 * dpr, 20 * dpr, 20 * dpr);
   } catch {
-    ctx.fillStyle = 'rgb(37, 37, 39)';
+    ctx.fillStyle = props.colorScheme === 'light' ? '#f7f8f9' : 'rgb(37, 37, 39)';
     ctx.lineWidth = dpr;
     ctx.beginPath();
     ctx.arc(left + 10 * dpr, top + 12 * dpr, 10 * dpr, 0, 2 * Math.PI);

--- a/packages/widgets-core/src/renderer/node/compose.ts
+++ b/packages/widgets-core/src/renderer/node/compose.ts
@@ -6,14 +6,14 @@ import { createWidgetContext } from '../../utils/context';
 import { renderCardHeader, renderLabelValue, renderAvatarLabel } from './builtin';
 import render from './index';
 
-export default async function renderCompose (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData) {
+export default async function renderCompose (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData, colorScheme?: string) {
   width = visualizer.width ?? width;
   height = visualizer.height ?? height;
   let canvas = createCanvas(width * dpr, height * dpr);
 
   const ctx = canvas.getContext('2d');
 
-  ctx.fillStyle = 'rgb(36, 35, 49)';
+  ctx.fillStyle = colorScheme === 'light' ? '#ffffff' : 'rgb(36, 35, 49)';
   ctx.fillRect(0, 0, width * dpr, height * dpr);
 
   const option: WidgetComposeItem[] = visualizer.default(data, {
@@ -28,6 +28,7 @@ export default async function renderCompose (width: number, height: number, dpr:
       case 'builtin:label':
       case 'builtin:label-value':
         renderLabelValue(canvas, {
+          colorScheme,
           label: item.parameters.label,
           value: item.parameters.value,
           box: {
@@ -41,6 +42,7 @@ export default async function renderCompose (width: number, height: number, dpr:
         break;
       case 'builtin:card-heading':
         renderCardHeader(canvas, {
+          colorScheme,
           title: item.parameters.title,
           subtitle: item.parameters.subtitle,
           box: {
@@ -54,6 +56,7 @@ export default async function renderCompose (width: number, height: number, dpr:
         break;
       case 'builtin:avatar-label':
         await renderAvatarLabel(canvas, {
+          colorScheme,
           label: item.parameters.label,
           imgSrc: item.parameters.imgSrc,
           box: {
@@ -67,7 +70,7 @@ export default async function renderCompose (width: number, height: number, dpr:
         break;
       default: {
         const visualizer = await visualizers[item.widget]();
-        const subCanvas = await render({ width: item.width / dpr, height: item.height / dpr, dpr: dpr, visualizer, data: item.data, parameters: item.parameters, linkedData, type: visualizer.type });
+        const subCanvas = await render({ width: item.width / dpr, height: item.height / dpr, dpr: dpr, visualizer, data: item.data, parameters: item.parameters, linkedData, type: visualizer.type, colorScheme });
         ctx.drawImage(subCanvas, item.left, item.top, item.width, item.height);
       }
     }

--- a/packages/widgets-core/src/renderer/node/echarts.ts
+++ b/packages/widgets-core/src/renderer/node/echarts.ts
@@ -6,7 +6,7 @@ import { createWidgetContext } from '../../utils/context';
 import '../echarts-theme';
 import '../echarts-map';
 
-export default function renderEcharts (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData) {
+export default function renderEcharts (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData, colorScheme?: string) {
   const dynamicHeight = visualizer.computeDynamicHeight?.(data);
   let canvas = createCanvas(width, dynamicHeight ?? height);
 
@@ -17,7 +17,7 @@ export default function renderEcharts (width: number, height: number, dpr: numbe
     ...createWidgetContext('server', parameters, linkedData),
   });
 
-  const echarts = init(canvas as any, 'dark', {
+  const echarts = init(canvas as any, colorScheme, {
     width: width,
     height: dynamicHeight ?? height,
     devicePixelRatio: dpr,

--- a/packages/widgets-core/src/renderer/node/index.ts
+++ b/packages/widgets-core/src/renderer/node/index.ts
@@ -6,16 +6,17 @@ export interface NodeWidgetVisualizationProps extends WidgetVisualizationProps {
   width: number;
   height: number;
   dpr: number;
+  colorScheme?: string;
 }
 
-export default async function render ({ type, width, height, dpr, visualizer, parameters, data, linkedData }: NodeWidgetVisualizationProps) {
+export default async function render ({ type, width, height, dpr, visualizer, parameters, data, linkedData, colorScheme }: NodeWidgetVisualizationProps) {
   switch (type) {
     case 'echarts':
-      return await import('./echarts').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData));
+      return await import('./echarts').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData, colorScheme));
     case 'react-svg':
-      return await import('./react-svg').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData));
+      return await import('./react-svg').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData, colorScheme));
     case 'compose':
-      return await import('./compose').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData));
+      return await import('./compose').then(module => module.default(width, height, dpr, visualizer, data, parameters, linkedData, colorScheme));
     default:
       throw new Error(`visualize type '${type}' not supported.`);
   }

--- a/packages/widgets-core/src/renderer/node/react-svg.ts
+++ b/packages/widgets-core/src/renderer/node/react-svg.ts
@@ -3,7 +3,7 @@ import { VisualizerModule } from '@ossinsight/widgets-types';
 import { LinkedData } from '../../parameters/resolver';
 import { createWidgetContext } from '../../utils/context';
 
-export default async function renderSvg (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData) {
+export default async function renderSvg (width: number, height: number, dpr: number, visualizer: VisualizerModule<any, any, any, any>, data: any, parameters: any, linkedData: LinkedData, colorScheme?: string) {
   width = visualizer.width ?? width;
   height = visualizer.height ?? height;
 
@@ -41,7 +41,7 @@ export default async function renderSvg (width: number, height: number, dpr: num
   }
 
   ctx.save();
-  ctx.fillStyle = 'rgb(31, 30, 40)';
+  ctx.fillStyle = colorScheme === 'light' ? 'white' : 'rgb(31, 30, 40)';
   ctx.rect(0, 0, width, height);
   ctx.fill();
   ctx.restore();

--- a/web/app/widgets/[vendor]/[name]/thumbnail.png/route.ts
+++ b/web/app/widgets/[vendor]/[name]/thumbnail.png/route.ts
@@ -7,7 +7,7 @@ import render from '@ossinsight/widgets-core/src/renderer/node';
 import { notFound } from 'next/navigation';
 import { NextRequest, NextResponse } from 'next/server';
 
-const EXCLUDED_PARAMETERS = ['image_size'];
+const EXCLUDED_PARAMETERS = ['image_size', 'color_scheme'];
 
 export async function GET (request: NextRequest, { params: { vendor, name: paramName } }: { params: { vendor: string, name: string } }) {
   if (vendor !== 'official') {
@@ -41,6 +41,8 @@ export async function GET (request: NextRequest, { params: { vendor, name: param
     parameters,
   });
 
+  const colorScheme = request.nextUrl.searchParams.get('color_scheme') ?? 'dark';
+
   const size = request.nextUrl.searchParams.get('image_size') ?? 'default';
   let width: number;
   let height: number;
@@ -65,6 +67,7 @@ export async function GET (request: NextRequest, { params: { vendor, name: param
     dpr: dpr ?? 2,
     parameters,
     linkedData,
+    colorScheme,
   });
 
   return new NextResponse(buffer.toBuffer('image/png'), {

--- a/widgets/compose-last-28-days-stats/visualization.ts
+++ b/widgets/compose-last-28-days-stats/visualization.ts
@@ -38,8 +38,8 @@ export default function ([[issues], [prs], [contributors], [stars]]: Input, ctx:
         item('@ossinsight/widget-analyze-repo-recent-pull-requests', 'PRs created', 'current_period_opened_prs', prs),
       ).gap(HORIZONTAL_SPACING).flex(),
       horizontal(
-        item('@ossinsight/widget-analyze-repo-recent-contributors', 'Active Contributors', 'current_period_contributors', contributors),
-        item('@ossinsight/widget-analyze-repo-recent-issues', 'Issues Opened', 'current_period_opened_issues', issues),
+        item('@ossinsight/widget-analyze-repo-recent-contributors', 'Contributors', 'current_period_contributors', contributors),
+        item('@ossinsight/widget-analyze-repo-recent-issues', 'Issues opened', 'current_period_opened_issues', issues),
       ).gap(HORIZONTAL_SPACING).flex(),
     ).padding([0, PADDING, PADDING]).gap(SPACING),
     0,


### PR DESCRIPTION
  <img src="https://ossinsight-next-git-fix-20230818-color-scheme-djagger.vercel.app/widgets/official/compose-last-28-days-stats/thumbnail.png?repo_id=41986369&image_size=auto" style="border-radius: 12px; box-shadow: 0px 4px 4px 0px rgba(36, 39, 56, 0.25)" width="654" height="auto" alt="Untitled">
  <img src="https://ossinsight-next-git-fix-20230818-color-scheme-djagger.vercel.app/widgets/official/compose-last-28-days-stats/thumbnail.png?repo_id=41986369&image_size=auto&color_scheme=light" style="border-radius: 12px; box-shadow: 0px 4px 4px 0px rgba(36, 39, 56, 0.25)" width="654" height="auto" alt="Untitled">

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://ossinsight-next-git-fix-20230818-color-scheme-djagger.vercel.app/widgets/official/compose-last-28-days-stats/thumbnail.png?repo_id=41986369&image_size=auto&color_scheme=dark" width="654" height="auto" style="border-radius: 12px; box-shadow: 0px 4px 4px 0px rgba(36, 39, 56, 0.25);">
  <img alt="Shows an illustrated sun in light color mode and a moon with stars in dark color mode." src="https://ossinsight-next-git-fix-20230818-color-scheme-djagger.vercel.app/widgets/official/compose-last-28-days-stats/thumbnail.png?repo_id=41986369&image_size=auto&color_scheme=light" width="654" height="auto" style="border-radius: 12px; box-shadow: 0px 4px 4px 0px rgba(219, 216, 199, 0.75);">
</picture>
