### PR TITLE
fix: revert x-axis of recent stats chart

### DIFF
--- a/packages/widgets-utils/src/options/axis.ts
+++ b/packages/widgets-utils/src/options/axis.ts
@@ -146,6 +146,7 @@ export function recentStatsChartXAxis<T extends 'x'>(
 ): AxisOption<T> {
   return merge<AxisOption<T>>(option, {
     type: 'category',
+    inverse: true,
     axisLine: {
       show: false,
     },


### PR DESCRIPTION
### Before
![7c0ef841-b979-439a-977e-96bc000cbdc5](https://github.com/pingcap/ossinsight-next/assets/12960671/1e0643ac-681d-449a-a102-b5d687d3f566)

### After
![5f8a1013-87a9-427f-8e3f-70e02b884adf](https://github.com/pingcap/ossinsight-next/assets/12960671/9d306d0e-c84e-4269-9e48-1112e16aeb28)
