### PR TITLE
widgets: fix wording to make it reasonable

### DIFF
--- a/widgets/compose/user/dashboard-stats/visualization.tsx
+++ b/widgets/compose/user/dashboard-stats/visualization.tsx
@@ -119,7 +119,7 @@ const handleOverview = (overview: PersonalOverviewDataPoint) => {
     ,
     {
       icon: 'gh-star',
-      label: 'Starred Earned',
+      label: 'Stars Earned',
       type: 'avatar-label',
     },
     {


### PR DESCRIPTION
Modifies "**Starred Earned**" to "**Stars Earned**" on https://next.ossinsight.io/widgets.

![image](https://github.com/user-attachments/assets/68abd00e-2c48-4df6-969c-32bf287af9b7)
